### PR TITLE
close connection on 'onClose' hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,14 @@ function fastifyArangoDB (fastify, options, next) {
     )
   }
   const arango = new ArangoDB.Database(options)
-  fastify.decorate('arango', arango)
+  fastify.decorate('arango', arango).addHook("onClose", close)
 
   next()
+}
+
+function close (fastify, done) {
+  fastify.arango.close()
+  done()
 }
 
 module.exports = fp(fastifyArangoDB, '>=0.13.1')

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function fastifyArangoDB (fastify, options, next) {
 }
 
 function close (fastify, done) {
-  fastify.arango.close()
+  fastify.arango.close && fastify.arango.close()
   done()
 }
 


### PR DESCRIPTION
API reference: https://docs.arangodb.com/devel/Drivers/JS/Reference/Database/#databaseclose
It was introduced in 6.4.0, so dependency should be updated for this to work